### PR TITLE
Replace complicated reflection-based middleware support w/ interface

### DIFF
--- a/XO.Console.Cli.Extensions/CommandAppFactory.cs
+++ b/XO.Console.Cli.Extensions/CommandAppFactory.cs
@@ -19,6 +19,9 @@ internal static class CommandAppFactory
             .SetApplicationName(context.HostingEnvironment.ApplicationName)
             .UseTypeResolver(resolver);
 
+        foreach (var middleware in services.GetServices<ICommandAppMiddleware>())
+            builder.UseMiddleware(middleware);
+
         foreach (var action in options.ConfigureActions)
             action(context, builder);
 

--- a/XO.Console.Cli.Extensions/CommandAppServiceCollectionExtensions.cs
+++ b/XO.Console.Cli.Extensions/CommandAppServiceCollectionExtensions.cs
@@ -62,6 +62,24 @@ public static class CommandAppServiceCollectionExtensions
             configure);
     }
 
+    /// <summary>
+    /// Adds the command execution middleware <typeparamref name="TMiddleware"/> to the service collection as a singleton service.
+    /// </summary>
+    /// <remarks>
+    /// At startup, the application will create an instance of each unique implementation of <see
+    /// cref="ICommandAppMiddleware"/> added to the service collection and add it to the command execution pipeline
+    /// using <see cref="ICommandAppBuilder.UseMiddleware(ICommandAppMiddleware)"/>.
+    /// </remarks>
+    /// <typeparam name="TMiddleware">The middleware implementation type.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to configure.</param>
+    /// <returns>The <see cref="IServiceCollection"/>.</returns>
+    public static IServiceCollection AddCommandAppMiddleware<TMiddleware>(this IServiceCollection services)
+        where TMiddleware : class, ICommandAppMiddleware
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<ICommandAppMiddleware, TMiddleware>());
+        return services;
+    }
+
     internal static IServiceCollection AddCommandApp(
         this IServiceCollection services,
         Func<ICommandAppBuilder>? builderFactory,

--- a/XO.Console.Cli/ICommandAppBuilder.cs
+++ b/XO.Console.Cli/ICommandAppBuilder.cs
@@ -110,25 +110,15 @@ public interface ICommandAppBuilder : ICommandBuilderProvider<ICommandAppBuilder
     /// <summary>
     /// Adds a middleware to the application pipeline.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <typeparamref name="TMiddleware"/> must have a single public constructor with a first parameter of type
-    /// <see cref="ExecutorDelegate"/>.
-    /// </para>
-    /// <para>
-    /// <typeparamref name="TMiddleware"/> must have a single method named <c>Execute</c> or <c>ExecuteAsync</c> that
-    /// takes a first parameter of type <see cref="CommandContext"/> and a last parameter of type
-    /// <see cref="CancellationToken"/>. Its return type must be <c>Task&lt;int&gt;</c>.
-    /// </para>
-    /// <para>
-    /// Additional constructor parameters and arguments to the execution method are populated from the
-    /// <see cref="ITypeResolver"/>, if possible. Constructor arguments are populated once, when the application is
-    /// built. Method arguments are populated at execution time.
-    /// </para>
-    /// </remarks>
-    /// <param name="args">Arguments to <typeparamref name="TMiddleware"/>'s constructor.</param>
+    /// <param name="middleware">The middleware implementation.</param>
+    ICommandAppBuilder UseMiddleware(ICommandAppMiddleware middleware);
+
+    /// <summary>
+    /// Adds a middleware to the application pipeline.
+    /// </summary>
     /// <typeparam name="TMiddleware">The middleware implementation type.</typeparam>
-    ICommandAppBuilder UseMiddleware<TMiddleware>(params object[] args);
+    ICommandAppBuilder UseMiddleware<TMiddleware>()
+        where TMiddleware : ICommandAppMiddleware;
 
     /// <summary>
     /// Sets the <see cref="ITypeResolver"/> used to create instances of command and middleware implementations.

--- a/XO.Console.Cli/ICommandAppMiddleware.cs
+++ b/XO.Console.Cli/ICommandAppMiddleware.cs
@@ -1,0 +1,19 @@
+namespace XO.Console.Cli;
+
+/// <summary>
+/// Represents a middleware service for <see cref="ICommandApp"/>.
+/// </summary>
+public interface ICommandAppMiddleware
+{
+    /// <summary>
+    /// Executes the middleware.
+    /// </summary>
+    /// <param name="next">The next delegate in the execution pipeline. Implementors must call this method to continue executing the command.</param>
+    /// <param name="context">The command execution context.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that may request that execution be canceled.</param>
+    /// <returns>
+    /// An exit code that describes the result of executing the command. Usually, this will be the return value of
+    /// <paramref name="next"/>, but implementors may choose to return other values as necessary.
+    /// </returns>
+    Task<int> ExecuteAsync(ExecutorDelegate next, CommandContext context, CancellationToken cancellationToken);
+}

--- a/XO.Console.Cli/Internal/MiddlewareAdapter.cs
+++ b/XO.Console.Cli/Internal/MiddlewareAdapter.cs
@@ -1,0 +1,16 @@
+namespace XO.Console.Cli;
+
+internal sealed class MiddlewareAdapter
+{
+    private readonly ICommandAppMiddleware _middleware;
+    private readonly ExecutorDelegate _next;
+
+    public MiddlewareAdapter(ICommandAppMiddleware middleware, ExecutorDelegate next)
+    {
+        _middleware = middleware;
+        _next = next;
+    }
+
+    public Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
+        => _middleware.ExecuteAsync(_next, context, cancellationToken);
+}

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.1-alpha",
+  "version": "4.0-alpha",
   "gitCommitIdPrefix": "ci.",
   "nuGetPackageVersion": {
     "semVer": 2.0


### PR DESCRIPTION
Middleware implemented as a class must implement `ICommandAppMiddleware`. The base library supports adding middleware by delegate, instance, or type. The extensions library enhances middleware support by automatically adding all services implementing `ICommandAppMiddleware` to the application.

Middleware that depends on scoped services should use `CommandContext.CommandServices` to access the execution scope.